### PR TITLE
Store history/content for each agent separately...

### DIFF
--- a/packages/lambda-src/ts-src/handleEventsEndpoint.ts
+++ b/packages/lambda-src/ts-src/handleEventsEndpoint.ts
@@ -49,7 +49,7 @@ export async function handleEventsEndpoint(event: APIGatewayProxyEvent): Promise
     case "message":
     case "app_mention": {
       const genericMessageEvent = envelopedEvent.event as GenericMessageEvent;
-      console.log(`handleEventsEndpoint genericMessageEvent: ${util.inspect(genericMessageEvent, false, null)}`);
+      //console.log(`handleEventsEndpoint genericMessageEvent: ${util.inspect(genericMessageEvent, false, null)}`);
 
       // Get our own user ID and ignore messages we have posted, otherwise we'll get into an infinite loop.
       const myId = await getBotId();

--- a/packages/lambda-src/ts-src/historyTable.ts
+++ b/packages/lambda-src/ts-src/historyTable.ts
@@ -8,20 +8,24 @@ const TTL_IN_MS = 1000 * 60 * 60 * 24 * 30; // Thirty days
 const TableName = "AIBot_History";
 
 export type History = {
-  slack_id: string,
+  channel_id: string,
   thread_ts: string,
   content: Content[]
 };
+export type GetHistoryFunction = (channelId: string, threadTs: string, agentName: string) => Promise<Content[] | undefined>;
+export type PutHistoryFunction = (channelId: string, threadTs: string, history: Content[], agentName: string) => Promise<void>;
+
 /**
- * Gets the History for the given user and thread id
- * @param slackId Slack user id 
+ * Gets the History for the given channel and thread id
+ * @param channelId Slack channel id 
  * @param threadTs the thread id for the conversation
- * @returns history or undefined if no history exists for the user and thread
+ * @param agentName the name of the agent to get the history for
+ * @returns history or undefined if no history exists for the channel and thread
  */
-export async function getHistory(slackId: string, threadTs: string) : Promise<Content[] | undefined>  { 
+export async function getHistory(channelId: string, threadTs: string, agentName: string) : Promise<Content[] | undefined>  { 
   const ddbClient = new DynamoDBClient({});
 
-  const id = `${slackId}_${threadTs}`;
+  const id = `${channelId}_${threadTs}_${agentName}`;
 
   const params: QueryCommandInput = {
     TableName,
@@ -41,10 +45,10 @@ export async function getHistory(slackId: string, threadTs: string) : Promise<Co
   }
 }
 
-export async function deleteHistory(slackId: string, threadTs: string) {
+export async function deleteHistory(channelId: string, threadTs: string, agentName: string) {
   const ddbClient = new DynamoDBClient({});
 
-  const id = `${slackId}_${threadTs}`;
+  const id = `${channelId}_${threadTs}_${agentName}`;
 
   const params: DeleteItemCommandInput = {
     TableName,
@@ -59,15 +63,17 @@ export async function deleteHistory(slackId: string, threadTs: string) {
 }
 
 /**
- * Put (ie save new or overwite) history with slackId and threadTs as the key
- * @param slackId Key for the table
+ * Put (ie save new or overwite) history with channelId and threadTs as the key
+ * @param channelId channel id
+ * @param threadTs thread timestamp
+ * @param agentName the name of the agent whose history this is
  * @param history history to write
  */
-export async function putHistory(slackId: string, threadTs: string, history: Content[]) {
+export async function putHistory(channelId: string, threadTs: string, history: Content[], agentName: string) {
   const now = Date.now();
   const ttl = new Date(now + TTL_IN_MS);
 
-  const id = `${slackId}_${threadTs}`;
+  const id = `${channelId}_${threadTs}_${agentName}`;
 
   const putItemCommandInput: PutItemCommandInput = {
     TableName,


### PR DESCRIPTION
.. rather than handing the entire conversation history to the sub agents.  This results in much less noise for the sub agents so they understand their own context much better.  This seems to reduce spurious 500 errors from Vertex AI too.  The supervisor also gets its own history where it can see the user prompts and the answers from the sub agents.

I suspect this will also help where the agents use different models from each other and/or the supervisor.  The history could be incompatible between models whereas they will only get their own history now.